### PR TITLE
tests didn't cover wrong impl (fixed it) 

### DIFF
--- a/src/test/java/core/basesyntax/JavaStreamApiTest.java
+++ b/src/test/java/core/basesyntax/JavaStreamApiTest.java
@@ -40,6 +40,7 @@ public class JavaStreamApiTest {
         peopleList.get(7).getCatList().add(new Cat("Jackie", 2));
         peopleList.add(new People("Roman", 25, People.Sex.MAN));
         peopleList.add(new People("Carlos", 60, People.Sex.MAN));
+        peopleList.add(new People("Kate", 10, People.Sex.WOMEN));
 
         peopleListWithoutCat = new ArrayList<>();
         peopleListWithoutCat.add(new People("Helen", 16, People.Sex.WOMEN));


### PR DESCRIPTION
 This solution was accepted by tests
- .filter(p -> p.getAge() >= fromAge
                           && p.getSex() == People.Sex.MAN && p.getAge() <= maleToAge
                           || p.getSex() == People.Sex.WOMEN && p.getAge() <= femaleToAge)
And correct impl should look like this (pay attention to brackets)
- .filter(p -> p.getAge() >= fromAge
                        && (p.getSex() == People.Sex.MAN && p.getAge() <= maleToAge
                        || p.getSex() == People.Sex.WOMEN && p.getAge() <= femaleToAge))
modified input data to cover this case 